### PR TITLE
Separate handling for each account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,9 @@ output.txt
 Thumbs.db
 
 # Settings Files
-/platforms/ibm/IbmCloudApi.json
-/platforms/ibm/cluster/.*
-/platforms/ibm/cluster/*.tfvars
-/platforms/ibm/cluster/*.tfstate
-/platforms/ibm/cluster/*.tfstate.backup
-/platforms/ibm/cluster/kubectl
+**/IbmCloudApi.json
+**/cluster/.*
+**/*.tfvars
+**/*.tfstate
+**/*.tfstate.backup
+**/kubectl

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 BC Gov OpenShift Container Platform deployment automation
 
+A tool for BC Gov hybrid-cloud cluster admins that allows fast reliable deployments of cloud vendor managed OpenShift clusters that integrate with the BC Gov multi-vendor hybrid cloud.
+
+Meant to be as simple as running 2 commands:
+
+```bash
+./prerequisites.sh;
+terraform apply;
+```
+
 ## Getting Started
 
 We are going to be using a set of tools to manage OpenShift cluster deployments.
@@ -13,8 +22,9 @@ These tools are:
 * vscode
 * asdf version manager
 * platform specific CLIs and plugins
+* a working cloud resources account at each vendor
 
-### Prerequisites
+### Automatic Installation of Prerequisites
 
 For each specific platform, run the installer to get started.
 
@@ -34,7 +44,7 @@ Run the following command (which is expected to complete in around 20 minutes). 
 
 ```bash
 #!/bin/bash
-cd platforms/ibm/cluster;
+cd platforms/ibm/accounts/<target-account-hash>/cluster;
 terraform apply;
 ```
 
@@ -46,6 +56,6 @@ Run the following command (which is expected to complete in around 4 minutes). W
 
 ```bash
 #!/bin/bash
-cd platforms/ibm/cluster;
+cd platforms/ibm/accounts/<target-account-hash>/cluster;
 terraform destroy;
 ```

--- a/platforms/ibm/account/1c0bb855451a158761219151e41f9a12/cluster/openshift.tf
+++ b/platforms/ibm/account/1c0bb855451a158761219151e41f9a12/cluster/openshift.tf
@@ -13,8 +13,8 @@ resource "ibm_container_cluster" "cluster" {
   machine_type      = "b3c.4x16"
   hardware          = "shared"
   kube_version      = "4.3_openshift"
-  public_vlan_id    = "2765144"
-  private_vlan_id   = "2765146"
+  public_vlan_id    = "2860432"
+  private_vlan_id   = "2860434"
   lifecycle {
     ignore_changes = [kube_version]
   }

--- a/platforms/ibm/prerequisites.sh
+++ b/platforms/ibm/prerequisites.sh
@@ -5,12 +5,7 @@ source "$CALLER_DIR/../../lib/setup_helper.sh";
 source "$CALLER_DIR/lib/ibm_cloud_components.sh";
 
 checkDependencies;
-installIbmCloudCliIfNeeded;
-installTerraformIfNeeded;
-installIbmTerraformPluginsIfNeeded;
-createIbmApiKeyIfNeeded;
-createIbmTerraformSettingsIfNeeded;
-initializeOpenshiftTfVlansIfNeeded;
+handleOrderDependentIbmCloudTerraformSetups;
 
 source "${PROFILE_FILE}";
 source "${RC_FILE}";


### PR DESCRIPTION
IBM Cloud provides different sets of resources depending on which account a user logs in to.

The default account tied to each user is considered 'dev' whereas other shared BC Gov org accounts would be considered 'prod'.

Created a storage structure in the file system such that terraform configurations are saved in source control without leaking account details.